### PR TITLE
Reset input field value after adding user

### DIFF
--- a/web/src/components/AddUserModal.jsx
+++ b/web/src/components/AddUserModal.jsx
@@ -37,6 +37,14 @@ export default function AddUserModal({
 
   const handleChange = createHandleChange(setFields, setErrors);
 
+  const resetFields = () => {
+    setFields({
+      rollNo: '',
+      email: '',
+    });
+  };
+
+
   return (
     <Modal
       isOpen={isOpen}
@@ -93,6 +101,7 @@ export default function AddUserModal({
               if (error) {
                 setErrors(error);
               } else {
+                resetFields();
                 mutate();
                 onClose();
               }


### PR DESCRIPTION
When we add a user and the user is added the input fields like roll number and email will now reset to an empty value.
#45

